### PR TITLE
Split input for li filter

### DIFF
--- a/emr_run_spark.py
+++ b/emr_run_spark.py
@@ -115,7 +115,7 @@ def _create_steps(job_flow_name=None,
         'Args': ['unzip', zip_file_on_host, '-d', sources_on_host]
       }
     })
-    for i in range(steps):
+    for i in range(num_of_steps):
         steps.append({
           'Name': 'run spark {}'.format(spark_main),
           'ActionOnFailure': 'CANCEL_AND_WAIT',

--- a/emr_run_spark.py
+++ b/emr_run_spark.py
@@ -16,7 +16,6 @@ def add_step_to_job_flow(job_flow_id=None,
                          spark_main=None,
                          py_files=None,
                          num_of_steps=1,
-                         str_format=None,
                          use_mysql=False,
                          spark_main_args=None,
                          s3_work_bucket=None,
@@ -31,7 +30,6 @@ def add_step_to_job_flow(job_flow_id=None,
                           spark_main=spark_main,
                           py_files=py_files,
                           num_of_steps=num_of_steps,
-                          str_format=str_format,
                           use_mysql=use_mysql,
                           spark_main_args=spark_main_args,
                           s3_work_bucket=s3_work_bucket,
@@ -64,7 +62,6 @@ def _create_steps(job_flow_name=None,
                   spark_main=None,
                   py_files=[],
                   num_of_steps=1,
-                  str_format='{:0>3}',
                   spark_main_args=None,
                   s3_work_bucket=None,
                   use_mysql=False,
@@ -127,7 +124,7 @@ def _create_steps(job_flow_name=None,
             'Args': (['spark-submit'] +
                      packages +
                      ['--py-files', zip_file_on_host, spark_main_on_host] +
-                     spark_main_args.format(str_format.format(i)).split())
+                     spark_main_args.format(i).split())
           }
         })
 
@@ -171,7 +168,6 @@ def create_cluster_and_run_job_flow(create_cluster_master_type=None,
                                     create_cluster_keep_alive_when_done=None,
                                     python_path=None,
                                     num_of_steps=1,
-                                    str_format='{:0>3}',
                                     spark_main=None,
                                     py_files=None,
                                     spark_main_args=None,
@@ -190,7 +186,6 @@ def create_cluster_and_run_job_flow(create_cluster_master_type=None,
                           spark_main=spark_main,
                           py_files=py_files,
                           num_of_steps=num_of_steps,
-                          str_format=str_format,
                           spark_main_args=spark_main_args,
                           s3_work_bucket=s3_work_bucket,
                           use_mysql=use_mysql,
@@ -325,7 +320,6 @@ if __name__ == '__main__':
     parser.add_argument('--send_success_email_to', default=None,
                         help='Email address to send on success')
     parser.add_argument('--num_of_steps', default=1, type=int)
-    parser.add_argument('--str_format', default='{:0>3}', type=int)
 
     args = parser.parse_args()
 
@@ -335,7 +329,6 @@ if __name__ == '__main__':
                              spark_main=args.spark_main,
                              spark_main_args=args.spark_main_args,
                              num_of_steps=args.num_of_steps,
-                             str_format=args.str_format,
                              py_files=args.py_files,
                              use_mysql=args.use_mysql,
                              s3_work_bucket=args.s3_work_bucket,
@@ -356,7 +349,6 @@ if __name__ == '__main__':
             use_mysql=args.use_mysql,
             spark_main_args=args.spark_main_args,
             num_of_steps=args.num_of_steps,
-            str_format=args.str_format,
             s3_work_bucket=args.s3_work_bucket,
             aws_region=args.aws_region,
             send_success_email_to=args.send_success_email_to)

--- a/emr_run_spark.py
+++ b/emr_run_spark.py
@@ -108,38 +108,13 @@ def _create_steps(job_flow_name=None,
         'Args': ['unzip', zip_file_on_host, '-d', sources_on_host]
       }
     })
-    if use_mysql:
-      steps.append({
-        'Name': 'setup - jars 1',
-        'ActionOnFailure': 'CANCEL_AND_WAIT',
-        'HadoopJarStep': {
-          'Jar': 'command-runner.jar',
-          'Args': 'touch /home/hadoop/noop.py'.split()
-        }
-      })
-      steps.append({
-        'Name': 'setup - jars 2',
-        'ActionOnFailure': 'CANCEL_AND_WAIT',
-        'HadoopJarStep': {
-          'Jar': 'command-runner.jar',
-          'Args': 'spark-submit --packages mysql:mysql-connector-java:5.1.38 /home/hadoop/noop.py'.split()
-        }
-      })
-      steps.append({
-        'Name': 'setup - jars 3',
-        'ActionOnFailure': 'CANCEL_AND_WAIT',
-        'HadoopJarStep': {
-          'Jar': 'command-runner.jar',
-          'Args': 'sudo cp /home/hadoop/.ivy2/jars/mysql_mysql-connector-java-5.1.38.jar /usr/lib/hadoop/'.split()
-        }
-      })
     steps.append({
       'Name': 'run spark {}'.format(spark_main),
       'ActionOnFailure': 'CANCEL_AND_WAIT',
       'HadoopJarStep': {
         'Jar': 'command-runner.jar',
         'Args': ['spark-submit', '--packages',
-                 'mysql:mysql-connector-java:5.1.38', '--py-files',
+                 'mysql:mysql-connector-java:5.1.39', '--py-files',
                  zip_file_on_host,
                  spark_main_on_host] + spark_main_args
       }
@@ -210,7 +185,7 @@ def create_cluster_and_run_job_flow(create_cluster_master_type=None,
     response = client.run_job_flow(
         Name=job_flow_name,
         LogUri=s3_logs_uri,
-        ReleaseLabel='emr-4.3.0',
+        ReleaseLabel='emr-4.6.0',
         Instances={
           'MasterInstanceType': create_cluster_master_type,
           'SlaveInstanceType': create_cluster_slave_type,
@@ -226,9 +201,15 @@ def create_cluster_and_run_job_flow(create_cluster_master_type=None,
           {
             'Classification': 'spark',
             'Properties': {
-                'maximizeResourceAllocation': 'true'
+               'maximizeResourceAllocation': 'true'
             }
           },
+          {
+            "Classification": "spark-defaults",
+            "Properties": {
+               "spark.dynamicAllocation.enabled": "true"
+            }
+          }
         ],
         VisibleToAllUsers=True,
         JobFlowRole='EMR_EC2_DefaultRole',

--- a/emr_run_spark.py
+++ b/emr_run_spark.py
@@ -89,7 +89,7 @@ def _create_steps(job_flow_name=None,
     subprocess.check_call('aws s3 cp {} {}'.format(local_zip_file, zip_file_on_s3), shell=True)
     zip_file_on_host = '{}/{}'.format(sources_on_host, zip_file)
     spark_main_on_host = '{}/{}'.format(sources_on_host, spark_main)
-    spark_main_args = spark_main_args.split() if spark_main_args else ['']
+    # spark_main_args = spark_main_args.split() if spark_main_args else ['']
     packages_to_add = []
     if use_mysql:
         packages_to_add.append('mysql:mysql-connector-java:5.1.39')
@@ -112,17 +112,18 @@ def _create_steps(job_flow_name=None,
         'Args': ['unzip', zip_file_on_host, '-d', sources_on_host]
       }
     })
-    steps.append({
-      'Name': 'run spark {}'.format(spark_main),
-      'ActionOnFailure': 'CANCEL_AND_WAIT',
-      'HadoopJarStep': {
-        'Jar': 'command-runner.jar',
-        'Args': (['spark-submit'] +
-                 packages +
-                 ['--py-files', zip_file_on_host, spark_main_on_host] +
-                 spark_main_args)
-      }
-    })
+    for i in range(20):
+        steps.append({
+          'Name': 'run spark {}'.format(spark_main),
+          'ActionOnFailure': 'CANCEL_AND_WAIT',
+          'HadoopJarStep': {
+            'Jar': 'command-runner.jar',
+            'Args': (['spark-submit'] +
+                     packages +
+                     ['--py-files', zip_file_on_host, spark_main_on_host] +
+                     spark_main_args.format('{:0>3}'.format(i)).split())
+          }
+        })
 
     if send_success_email_to is not None:
         steps.append({

--- a/emr_run_spark.py
+++ b/emr_run_spark.py
@@ -15,6 +15,8 @@ def add_step_to_job_flow(job_flow_id=None,
                          python_path=None,
                          spark_main=None,
                          py_files=None,
+                         num_of_steps=1,
+                         str_format=None,
                          use_mysql=False,
                          spark_main_args=None,
                          s3_work_bucket=None,
@@ -28,6 +30,8 @@ def add_step_to_job_flow(job_flow_id=None,
                           python_path=python_path,
                           spark_main=spark_main,
                           py_files=py_files,
+                          num_of_steps=num_of_steps,
+                          str_format=str_format,
                           use_mysql=use_mysql,
                           spark_main_args=spark_main_args,
                           s3_work_bucket=s3_work_bucket,
@@ -59,6 +63,8 @@ def _create_steps(job_flow_name=None,
                   python_path=None,
                   spark_main=None,
                   py_files=[],
+                  num_of_steps=1,
+                  str_format='{:0>3}',
                   spark_main_args=None,
                   s3_work_bucket=None,
                   use_mysql=False,
@@ -112,7 +118,7 @@ def _create_steps(job_flow_name=None,
         'Args': ['unzip', zip_file_on_host, '-d', sources_on_host]
       }
     })
-    for i in range(20):
+    for i in range(steps):
         steps.append({
           'Name': 'run spark {}'.format(spark_main),
           'ActionOnFailure': 'CANCEL_AND_WAIT',
@@ -121,7 +127,7 @@ def _create_steps(job_flow_name=None,
             'Args': (['spark-submit'] +
                      packages +
                      ['--py-files', zip_file_on_host, spark_main_on_host] +
-                     spark_main_args.format('{:0>3}'.format(i)).split())
+                     spark_main_args.format(str_format.format(i)).split())
           }
         })
 
@@ -164,6 +170,8 @@ def create_cluster_and_run_job_flow(create_cluster_master_type=None,
                                     create_cluster_setup_debug=None,
                                     create_cluster_keep_alive_when_done=None,
                                     python_path=None,
+                                    num_of_steps=1,
+                                    str_format='{:0>3}',
                                     spark_main=None,
                                     py_files=None,
                                     spark_main_args=None,
@@ -181,6 +189,8 @@ def create_cluster_and_run_job_flow(create_cluster_master_type=None,
                           python_path=python_path,
                           spark_main=spark_main,
                           py_files=py_files,
+                          num_of_steps=num_of_steps,
+                          str_format=str_format,
                           spark_main_args=spark_main_args,
                           s3_work_bucket=s3_work_bucket,
                           use_mysql=use_mysql,
@@ -314,6 +324,8 @@ if __name__ == '__main__':
                         action='store_true')
     parser.add_argument('--send_success_email_to', default=None,
                         help='Email address to send on success')
+    parser.add_argument('--num_of_steps', default=1, type=int)
+    parser.add_argument('--str_format', default='{:0>3}', type=int)
 
     args = parser.parse_args()
 
@@ -322,6 +334,8 @@ if __name__ == '__main__':
                              python_path=args.python_path,
                              spark_main=args.spark_main,
                              spark_main_args=args.spark_main_args,
+                             num_of_steps=args.num_of_steps,
+                             str_format=args.str_format,
                              py_files=args.py_files,
                              use_mysql=args.use_mysql,
                              s3_work_bucket=args.s3_work_bucket,
@@ -341,6 +355,8 @@ if __name__ == '__main__':
             py_files=args.py_files,
             use_mysql=args.use_mysql,
             spark_main_args=args.spark_main_args,
+            num_of_steps=args.num_of_steps,
+            str_format=args.str_format,
             s3_work_bucket=args.s3_work_bucket,
             aws_region=args.aws_region,
             send_success_email_to=args.send_success_email_to)


### PR DESCRIPTION
support splitting the data read from S3 to separate emr steps.
right now limited only to 10.
added as workaround to the filter users jobs.
